### PR TITLE
Update PGP key url to include www

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
                     <p>The <code>stable</code> channel is updated with stable release builds, usually every first
                         Tuesday of the month.</p>
                     <pre># Add the release PGP keys:
-<b>curl -s https://syncthing.net/release-key.txt | sudo apt-key add -</b>
+<b>curl -s https://www.syncthing.net/release-key.txt | sudo apt-key add -</b>
 
 # Add the "stable" channel to your APT sources:
 <b>echo "deb https://apt.syncthing.net/ syncthing stable" | sudo tee /etc/apt/sources.list.d/syncthing.list</b>


### PR DESCRIPTION
The Syncthing site, including the PGP key, is now under the www.syncthing.net. I've updated the instructions to reflect that. Otherwise, the curl command will follow the redirect, causing the apt-key command to fail. 