### PR TITLE
Replace deprecated use of apt-key

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
                     <p>To allow the system to check the packages authenticity, you need to provide the release key.</p>
                     <pre># Add the release PGP keys:
-<b>curl -s https://syncthing.net/release-key.txt | sudo apt-key add -</b></pre>
+<b>curl -s https://syncthing.net/release-key.txt | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/syncthing.gpg</b></pre>
 
                     <p>The <code>stable</code> channel is updated with stable release builds, usually every first
                         Tuesday of the month.</p>

--- a/index.html
+++ b/index.html
@@ -40,18 +40,18 @@
 
                     <p>To allow the system to check the packages authenticity, you need to provide the release key.</p>
                     <pre># Add the release PGP keys:
-<b>curl -s https://syncthing.net/release-key.txt | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/syncthing.gpg</b></pre>
+<b>sudo curl -s -o /usr/share/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg</b></pre>
 
                     <p>The <code>stable</code> channel is updated with stable release builds, usually every first
                         Tuesday of the month.</p>
                     <pre># Add the "stable" channel to your APT sources:
-<b>echo "deb https://apt.syncthing.net/ syncthing stable" | sudo tee /etc/apt/sources.list.d/syncthing.list</b></pre>
+<b>echo "deb [signed-by=/usr/share/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing stable" | sudo tee /etc/apt/sources.list.d/syncthing.list</b></pre>
 
                     <p>The <code>candidate</code> channel is updated with release candidate builds, usually every
                         second Tuesday of the month. These predate the corresponding stable builds by about three
                         weeks.</p>
                     <pre># Add the "candidate" channel to your APT sources:
-<b>echo "deb https://apt.syncthing.net/ syncthing candidate" | sudo tee /etc/apt/sources.list.d/syncthing.list</b></pre>
+<b>echo "deb [signed-by=/usr/share/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing candidate" | sudo tee /etc/apt/sources.list.d/syncthing.list</b></pre>
 
                     <p>To make sure the system packages do not take preference over those in this repository, you need to adjust the priority/preference.</p>
                     <pre># Increase preference of Syncthing's packages ("pinning")


### PR DESCRIPTION
See `apt-key` manpages. Fixes #6 