### PR TITLE
Extend tips for troubleshooting APT installation errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,19 @@ E: Failed to fetch https://apt.syncthing.net/dists/syncthing/InRelease
                     <pre><b>sudo apt-get install apt-transport-https</b></pre>
                 </div>
             </div>
+
+            <div class="row">
+                <div class="col-md-12">
+                    <h2>Server Certificate Verification Failed</h2>
+                    <p>Especially for older distributions, your system TLS certificate store might be outdated.  Since October 2021, a newer Let's Encrypt root certificate must be installed, or you may see an error similar to the following when running <code>apt-get</code>:</p>
+                    <pre>E: Failed to fetch https://apt.syncthing.net/dists/syncthing/stable/binary-armhf/Packages
+server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
+E: Some index files failed to download. They have been ignored, or old ones used instead.</pre>
+                    <p>Please make sure you have the latest version of the <code>ca-certificates</code> package and try again:</p>
+                    <pre><b>sudo apt-get update
+sudo apt-get upgrade ca-certificates</b></pre>
+                </div>
+            </div>
             <hr />
             <div class="row">
                 <div class="col-md-12">


### PR DESCRIPTION
As the recent expiration of the old Let's Encrypt root certificate has caused confusion and repeated questions on the forum, the APT web page could give some advice on how to deal with that.  This PR also separates the troubleshooting remarks from the absolutely necessary steps.

In my experience, pinning the package has never been necessary as this repo always has the upstream version.  So that part goes to the troubleshooting section as well.

The error message about the TLS certificate chain issue is taken [from the forum](https://forum.syncthing.net/t/no-longer-able-to-install-on-raspberry-pi/17491/13?u=acolomb).  I could not reproduce the problem even when downgrading `ca-certificates` to an ancient version.

Preview at https://htmlpreview.github.io/?https://github.com/acolomb/syncthing-apt-web/blob/troubleshooting-tips/index.html