### PR TITLE
Remove silent flag from curl

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
                     <p>To allow the system to check the packages authenticity, you need to provide the release key.</p>
                     <pre># Add the release PGP keys:
-<b>sudo curl -s -o /usr/share/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg</b></pre>
+<b>sudo curl -o /usr/share/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg</b></pre>
 
                     <p>The <code>stable</code> channel is updated with stable release builds, usually every first
                         Tuesday of the month.</p>


### PR DESCRIPTION
This hides potential errors and can lead to confusion.

See https://github.com/syncthing/docs/issues/757