### PR TITLE
fix instructions: make curl processing redirects

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
                     <p>To allow the system to check the packages authenticity, you need to provide the release key.</p>
                     <pre># Add the release PGP keys:
 <b>sudo mkdir -p /etc/apt/keyrings
-sudo curl -o /etc/apt/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg</b></pre>
+sudo curl -Lo /etc/apt/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg</b></pre>
 
                     <p>The <code>stable</code> channel is updated with stable release builds, usually every first
                         Tuesday of the month.</p>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
                     <p>To allow the system to check the packages authenticity, you need to provide the release key.</p>
                     <pre># Add the release PGP keys:
 <b>sudo mkdir -p /etc/apt/keyrings
-sudo curl -Lo /etc/apt/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg</b></pre>
+sudo curl -L -o /etc/apt/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg</b></pre>
 
                     <p>The <code>stable</code> channel is updated with stable release builds, usually every first
                         Tuesday of the month.</p>


### PR DESCRIPTION
By default, curl does not follow HTTP redirects, so if there are any, the key will not be added correctly. Adding -L key fixes it.